### PR TITLE
SGB Save Implementation Overrides

### DIFF
--- a/Runtime/Scripts/SGBSaveInfo.cs
+++ b/Runtime/Scripts/SGBSaveInfo.cs
@@ -1,0 +1,46 @@
+using System;
+
+namespace BobboNet.SGB.IMod
+{
+    /// <summary>
+    /// Information about an SGB save file.
+    /// </summary>
+    [System.Serializable]
+    public class SGBSaveInfo
+    {
+        /// <summary>
+        /// The save index that this file belongs to. Must be >= 0 to be considered valid.
+        /// </summary>
+        public int Index { get; set; } = -1;
+
+        /// <summary>
+        /// Does this save file exist? If false, this is treated as an empty slot.
+        /// </summary>
+        /// 
+        public bool Exists { get; set; } = false;
+
+        /// <summary>
+        /// The last time this save file was written to.
+        /// </summary>
+        public DateTime LastSaveDate { get; set; } = DateTime.Now;
+
+        //
+        //  Public Static Methods
+        //
+
+        /// <summary>
+        /// Is the given save file loadable?
+        /// In this context, loadable means that the save file exists and is valid.
+        /// </summary>
+        /// <param name="saveInfo">Information about the SGB save to query.</param>
+        /// <returns>true if loadable, false otherwise.</returns>
+        public static bool IsLoadable(SGBSaveInfo saveInfo)
+        {
+            if (saveInfo == null) return false;
+            if (saveInfo.Index < 0) return false;
+            if (!saveInfo.Exists) return false;
+
+            return true;
+        }
+    }
+}

--- a/Runtime/Scripts/SGBSaveInfo.cs
+++ b/Runtime/Scripts/SGBSaveInfo.cs
@@ -25,6 +25,14 @@ namespace BobboNet.SGB.IMod
         public DateTime LastSaveDate { get; set; } = DateTime.Now;
 
         //
+        //  Factory Methods
+        //
+
+        public static SGBSaveInfo NewEmpty() => new SGBSaveInfo();
+        public static SGBSaveInfo NewEmpty(int slotIndex) => new SGBSaveInfo() { Index = slotIndex };
+        public static SGBSaveInfo NewReal(int slotIndex, DateTime saveDate) => new SGBSaveInfo() { Exists = true, Index = slotIndex, LastSaveDate = saveDate };
+
+        //
         //  Public Static Methods
         //
 

--- a/Runtime/Scripts/SGBSaveInfo.cs.meta
+++ b/Runtime/Scripts/SGBSaveInfo.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c9c26f33c6f6e844caa4a8f4a4d4ce81
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Scripts/SGBSaveManager.cs
+++ b/Runtime/Scripts/SGBSaveManager.cs
@@ -20,6 +20,13 @@ namespace BobboNet.SGB.IMod
         public delegate void SaveDataDelegate(int saveIndex, Stream dataToSave);
 
         /// <summary>
+        /// A function that implements reading info about an SGB save file.
+        /// </summary>
+        /// <param name="saveIndex">The index of the SGB save data to get info on.</param>
+        /// <returns>The info requested about the given save data.</returns>
+        public delegate SGBSaveInfo ReadSaveInfoDelegate(int saveIndex);
+
+        /// <summary>
         /// A function that implements loading raw SGB save data from somewhere.
         /// </summary>
         /// <param name="saveIndex">The index of the SGB save data to load.</param>
@@ -37,6 +44,14 @@ namespace BobboNet.SGB.IMod
         /// the current save data as a binary stream.
         /// </summary>
         public static SaveDataDelegate SaveDataOverrideFunc { get; set; } = null;
+
+        /// <summary>
+        /// The function to use when overriding SGB's save data querying functionality.
+        /// If this is null, there is no override and SGB will query details about save data normally.
+        /// If this is populated, then whenever SGB needs to get data about a save file, it will call this
+        /// function.
+        /// </summary>
+        public static ReadSaveInfoDelegate ReadSaveInfoOverrideFunc { get; set; } = null;
 
         /// <summary>
         /// The function to use when overriding SGB's load data stream funcitonality.

--- a/Runtime/Scripts/SGBSaveManager.cs
+++ b/Runtime/Scripts/SGBSaveManager.cs
@@ -1,0 +1,60 @@
+using System.Collections;
+using System.Collections.Generic;
+using System.IO;
+using UnityEngine;
+using Yukar.Engine;
+
+namespace BobboNet.SGB.IMod
+{
+    public static class SGBSaveManager
+    {
+        //
+        //  Delegates
+        //
+
+        /// <summary>
+        /// A function that implements saving raw SGB save data somewhere.
+        /// </summary>
+        /// <param name="saveIndex">The index of the SGB save data to save.</param>
+        /// <param name="dataToSave">The raw binary data of the SGB save file</param>
+        public delegate void SaveDataDelegate(int saveIndex, Stream dataToSave);
+
+        /// <summary>
+        /// A function that implements loading raw SGB save data from somewhere.
+        /// </summary>
+        /// <param name="saveIndex">The index of the SGB save data to load.</param>
+        /// <returns>A stream holding the raw binary data of the SGB save file</returns>
+        public delegate Stream LoadDataDelegate(int saveIndex);
+
+        //
+        //  Properties
+        //
+
+        /// <summary>
+        /// The function to use when overriding SGB's save data stream functionality.
+        /// If this is null, there is no override and SGB will save as normal.
+        /// If this is populated, SGB will call this function after formatting
+        /// the current save data as a binary stream.
+        /// </summary>
+        public static SaveDataDelegate SaveDataOverrideFunc { get; set; } = null;
+
+        /// <summary>
+        /// The function to use when overriding SGB's load data stream funcitonality.
+        /// If this is null, there is no override and SGB will load as normal.
+        /// If this is populated, SGB will call this function to get a stream to read
+        /// from when parsing binary data.
+        /// </summary>
+        public static LoadDataDelegate LoadDataOverrideFunc { get; set; } = null;
+
+        //
+        //  Constructor
+        //
+
+        static SGBSaveManager()
+        {
+
+        }
+
+
+    }
+}

--- a/Runtime/Scripts/SGBSaveManager.cs.meta
+++ b/Runtime/Scripts/SGBSaveManager.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e16c385072e544c449a5ad08c420e35d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/src/common/GameDataManager.cs
+++ b/Runtime/src/common/GameDataManager.cs
@@ -166,6 +166,13 @@ namespace Yukar.Common
             else
             {
                 stream = SGBSaveManager.LoadDataOverrideFunc(index);
+
+                // If there's no save and the given index, return an empty save
+                if (stream == null)
+                {
+                    result.inititalize(catalog);
+                    return result;
+                }
             }
 #endif
             var reader = new BinaryReader(stream);
@@ -268,6 +275,13 @@ namespace Yukar.Common
             else
             {
                 stream = SGBSaveManager.LoadDataOverrideFunc(index);
+
+                // If there's no save and the given index, return an empty save
+                if (stream == null)
+                {
+                    result.inititalize(catalog);
+                    return result;
+                }
             }
 #endif
 

--- a/Runtime/src/common/Util/Util.cs
+++ b/Runtime/src/common/Util/Util.cs
@@ -413,8 +413,23 @@ namespace Yukar.Common
             return false;
         }
 
+        /// <returns>true if we are running on a JP system, false otherwise.</returns>
+        public static bool getIsJapanese()
+        {
+#if WINDOWS
+            return System.Globalization.CultureInfo.CurrentCulture.Name == "ja-JP";
+#else
+            return UnityEngine.Application.systemLanguage == UnityEngine.SystemLanguage.Japanese;
+#endif
+        }
+
         public static string getSaveDate(int idx, bool multiLine = false)
         {
+#if IMOD
+            // Get the write date of the desired save file. If it doesn't exist, EXIT EARLY.
+            DateTime date;
+            if (!GameDataManager.GetSaveFileDate(idx, out date)) return "";
+#else // !IMOD            
 #if WINDOWS
             var path = Yukar.Common.GameDataManager.GetDataPath(idx);
             if (!Util.file.exists(path))
@@ -423,8 +438,7 @@ namespace Yukar.Common
             if (!Util.file.exists(path))
                 return "";
             var date = File.GetLastWriteTime(path);
-            bool isJapanese = System.Globalization.CultureInfo.CurrentCulture.Name == "ja-JP";
-#else
+#else // !WINDOWS
             var dateStr = GameDataManager.LoadDate(idx);
             if (dateStr == "")
             {
@@ -432,10 +446,10 @@ namespace Yukar.Common
             }
             var date = new DateTime();
             DateTime.TryParse(dateStr, out date);
-            bool isJapanese = UnityEngine.Application.systemLanguage == UnityEngine.SystemLanguage.Japanese;
-#endif
+#endif // (WINDOWS)
+#endif // (IMOD)
 
-            if (isJapanese)
+            if (getIsJapanese())
             {
                 return date.ToString("yy/MM/dd") + (multiLine ? "\n" : " ") + date.ToString("HH:mm:ss");
             }
@@ -579,7 +593,7 @@ namespace Yukar.Common
             float screenAspect = (float)UnityEngine.Screen.height / UnityEngine.Screen.width;
             float fixRatio = defaultAspect / screenAspect;
             x = (int)((v4.x * fixRatio * 0.25f + 0.5f) * viewportX);
-            y = (int)((v4.y * - 0.25f + 0.5f) * viewportY);
+            y = (int)((v4.y * -0.25f + 0.5f) * viewportY);
 #endif
             return v4.z;
         }


### PR DESCRIPTION
This PR introduces the SGB Save Manager into IMOD. This class allows you to optionally override how SGB saves, stores, and queries save data. This is necessary for Dome-King and the naninovel plugin, because we want to store SGB save data alongside the naninovel state.