### PR TITLE
Direct SGB Map Loading with LoadSmileGameAsync

### DIFF
--- a/Runtime/Scripts/SGBManager.cs
+++ b/Runtime/Scripts/SGBManager.cs
@@ -6,6 +6,7 @@ using System.IO;
 using UnityEngine;
 using UnityEngine.SceneManagement;
 using Yukar.Common;
+using Yukar.Engine;
 
 namespace BobboNet.SGB.IMod
 {
@@ -135,8 +136,9 @@ namespace BobboNet.SGB.IMod
                 InitializeSGBEntry(createdEntryPoint);
 
                 // ...reset SGB's state, load the first save file, and boot DIRECTLY into the map scene.
+                GameMain.isLoadingOverrideMap = true;
                 UnityEntry.game.DoReset(true, false);
-                UnityEntry.game.DoLoad(0);
+                UnityEntry.game.DoLoad(0, false);
                 UnityEntry.game.ChangeScene(Yukar.Engine.GameMain.Scenes.MAP);
 
                 // If we should load a specific map...
@@ -154,6 +156,8 @@ namespace BobboNet.SGB.IMod
                     }
                 }
 
+                // Mark that we are done manually loading into a map
+                GameMain.isLoadingOverrideMap = false;
             }
         }
 

--- a/Runtime/Scripts/SGBManager.cs
+++ b/Runtime/Scripts/SGBManager.cs
@@ -62,12 +62,15 @@ namespace BobboNet.SGB.IMod
                 changeMapParameters.guid = map.guId;
                 changeMapParameters.x = StartPosition.x;
                 changeMapParameters.y = StartPosition.y;
+                changeMapParameters.height = StartHeight;
+                changeMapParameters.dir = StartDirection;
+
+                // The following parameters are left alone, but could be implemented in the future. 
+                //
                 // changeMapParameters.createHero = true;
                 // changeMapParameters.eventStates = data.start.events;
-                changeMapParameters.height = StartHeight;
                 // changeMapParameters.camera = data.start.camera;
                 // changeMapParameters.spriteStates = data.start.sprites;
-                changeMapParameters.dir = StartDirection;
                 // changeMapParameters.playerLock = data.start.plLock;
                 // changeMapParameters.cameraLockByEvent = data.start.camLockedByEvent;
                 // changeMapParameters.cameraLock = data.start.camLock;

--- a/Runtime/src/engine/GameMain.cs
+++ b/Runtime/src/engine/GameMain.cs
@@ -57,6 +57,10 @@ namespace Yukar.Engine
 
         public static GameMain instance { get; private set; }
 
+#if IMOD
+        internal static bool isLoadingOverrideMap = false;
+#endif
+
         public bool IsBattle2D
         {
             get
@@ -786,6 +790,9 @@ namespace Yukar.Engine
                     titleScene.Update();
                     break;
                 case Scenes.MAP:
+#if IMOD
+                    if (isLoadingOverrideMap) break;
+#endif
                     mapScene.Update();
                     break;
                 case Scenes.BATTLE_TEST:
@@ -999,7 +1006,7 @@ namespace Yukar.Engine
             return mapScene.menuWindow.res;
         }
 
-        internal void DoLoad(int index)
+        internal void DoLoad(int index, bool loadMap = true)
         {
             data = Yukar.Common.GameDataManager.Load(catalog, index);
             float bgmVolume = 0.5f;
@@ -1015,7 +1022,7 @@ namespace Yukar.Engine
 #endif
             Audio.setMasterVolume(bgmVolume, seVolume);
 
-            DoReset(false); // データがもうあるので初期化しない
+            DoReset(false, loadMap); // データがもうあるので初期化しない
         }
 
         internal void DoSave(int index)

--- a/Runtime/src/engine/MapScene/MapScene.cs
+++ b/Runtime/src/engine/MapScene/MapScene.cs
@@ -47,7 +47,7 @@ namespace Yukar.Engine
 
         // マップキャラ
         internal List<MapCharacter> mapCharList = new List<MapCharacter>();
-        
+
         //同期
         internal ScriptRunner dialoguePushedRunner;
         internal ScriptRunner excludedScript;
@@ -474,7 +474,7 @@ namespace Yukar.Engine
 
             spManager.owner = this;
 
-            if(withBattle)
+            if (withBattle)
                 battleSequenceManager = new BattleSequenceManager(owner, owner.catalog, new WindowDrawer(winRes, winImgId), new WindowDrawer(winRes, winImgId));
         }
 
@@ -645,7 +645,7 @@ namespace Yukar.Engine
             }
             // 前のマップで画面遷移を実行したスクリプトはそのまま動かす
             excludedScript = null;
-			cameraControlledScript = null;
+            cameraControlledScript = null;
             if (callReserveRunner != null && callReserveRunner.script != null)
             {
                 callReserveRunner.removeTrigger = ScriptRunner.RemoveTrigger.ON_EXIT;
@@ -780,7 +780,7 @@ namespace Yukar.Engine
             UnityEntry.reserveClearFB();
 #endif
         }
-        
+
         internal void updateMapGeometry()
         {
             mapDrawer.Update(GameMain.getElapsedTime());
@@ -1251,7 +1251,7 @@ namespace Yukar.Engine
 
             return result;
         }
-        
+
         internal void ProcParallelScript()
         {
             UnityUtil.changeScene(UnityUtil.SceneType.MAP);
@@ -1366,7 +1366,11 @@ namespace Yukar.Engine
          */
         internal void Draw()
         {
-            if (isLoading || isBattleLoading)
+            if (isLoading || isBattleLoading
+#if IMOD
+                || GameMain.isLoadingOverrideMap
+#endif
+            )
             {
                 // スクリーンカラーを適用
                 Graphics.DrawFillRect(0, 0, Graphics.ViewportWidth, Graphics.ViewportHeight,
@@ -1724,7 +1728,7 @@ namespace Yukar.Engine
             float screenAspect = (float)UnityEngine.Screen.height / (float)UnityEngine.Screen.width;
             float fixRatio = defaultAspect / screenAspect;
             x = (int)((v4.x * fixRatio * 0.25f + 0.5f) * Graphics.ViewportWidth);
-            y = (int)((v4.y * - 0.25f + 0.5f) * Graphics.ViewportHeight);
+            y = (int)((v4.y * -0.25f + 0.5f) * Graphics.ViewportHeight);
 #endif
             var z = Util.getScreenPos(pp, vv, v4, out x, out y, Graphics.ViewportWidth, Graphics.ViewportHeight);
 
@@ -1755,7 +1759,7 @@ namespace Yukar.Engine
 
         internal float GetRandom(float max, float min)
         {
-            if(min > max)
+            if (min > max)
             {
                 var tmp = min;
                 min = max;
@@ -2151,7 +2155,8 @@ namespace Yukar.Engine
             EndFadeOut = MoveMap;
             EndFadeOut += StartFadeIn;
             EndFadeIn = ExecGameoverEvent;
-            EndExecEvent += () => {
+            EndExecEvent += () =>
+            {
                 EndExecEvent = null;
                 UnlockControl();
                 ExclusionAllEvents(null);


### PR DESCRIPTION
This PR revises the LoadSmileGameAsync method to support loading into specific SGB maps and even go to specific positions in those maps. The intended purpose is to give greater control over SGB loading, and allow bypassing the title screen entirely.