### PR TITLE
Direct SGB Map Loading uses Pre-Load Operations

### DIFF
--- a/Runtime/Scripts/SGBManager.cs
+++ b/Runtime/Scripts/SGBManager.cs
@@ -72,22 +72,7 @@ namespace BobboNet.SGB.IMod
                 GameMain.isLoadingOverrideMap = true;
                 UnityEntry.game.DoReset(true, false);
                 UnityEntry.game.DoLoad(0, false);
-                UnityEntry.game.ChangeScene(Yukar.Engine.GameMain.Scenes.MAP);
-
-                // If we should load a specific map...
-                if (loadMapArgs != null)
-                {
-                    // Load the map for these entry details. If we can't find it, issue a warning.
-                    var mapToLoad = loadMapArgs.GetMap(UnityEntry.game.catalog);
-                    if (mapToLoad == null)
-                    {
-                        Debug.LogWarning($"Failed to find an SGB map with the name '{mapToLoad}'..! Ignoring...");
-                    }
-                    else
-                    {
-                        UnityEntry.game.mapScene.ChangeMap(loadMapArgs.GenerateChangeMapParams(mapToLoad));
-                    }
-                }
+                SGBMapLoadManager.LoadMap(loadMapArgs);
 
                 // Mark that we are done manually loading into a map
                 GameMain.isLoadingOverrideMap = false;

--- a/Runtime/Scripts/SGBMapLoadManager.cs
+++ b/Runtime/Scripts/SGBMapLoadManager.cs
@@ -3,6 +3,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.IO;
 using UnityEngine;
+using Yukar.Engine;
 
 namespace BobboNet.SGB.IMod
 {
@@ -51,6 +52,53 @@ namespace BobboNet.SGB.IMod
                 Debug.Log($"Loading SGB Map {args.Guid}{(args.Map != null ? $" - '{args.Map.name}'" : "")}");
                 return ApproveEventResult.Approve;
             });
+        }
+
+        //
+        //  Methods
+        //
+
+        /// <summary>
+        /// Load directly into an SGB map
+        /// </summary>
+        /// <param name="loadMapArgs">The details about what map to load into, and where to put the player.</param>
+        public static void LoadMap(LoadSGBMapArgs loadMapArgs = null)
+        {
+            // If we don't have any specific map to load, just load the default map and EXIT EARLY
+            if (loadMapArgs == null)
+            {
+                UnityEntry.game.ChangeScene(GameMain.Scenes.MAP);
+                return;
+            }
+
+            // OTHERWISE... we DO have a specific map to load, so...
+            // Load the map that our args refer to. If we can't find it, issue a warning.
+            var mapToLoad = loadMapArgs.GetMap(UnityEntry.game.catalog);
+            if (mapToLoad == null)
+            {
+                Debug.LogWarning($"Failed to find an SGB map with the name '{mapToLoad}'..! Ignoring...");
+                UnityEntry.game.ChangeScene(GameMain.Scenes.MAP);
+                return;
+            }
+
+            // Create a delegate that says to IGNORE loading any maps that are NOT the desired map
+            PreLoadEvent.EventDelegate temporaryPreloadEvent = delegate (PreLoadApprovalArgs args)
+            {
+                return (args.Guid == mapToLoad.guId) ? ApproveEventResult.Approve : ApproveEventResult.Error;
+            };
+
+            // 1. Setup the preload event that will STOP SGB from loading any maps EXCEPT the one we want
+            OnPreLoad.AddApprovalSource(temporaryPreloadEvent);
+
+            // 2. Tell SGB to internally get ready for the map scene
+            UnityEntry.game.ChangeScene(GameMain.Scenes.MAP);
+
+            // 3. Directly load to the desired map
+            MapScene.ChangeMapParams changeMapArgs = loadMapArgs.GenerateChangeMapParams(mapToLoad);
+            UnityEntry.game.mapScene.ChangeMap(changeMapArgs);
+
+            // 4. Remove the preload event from earlier, so that we can load any maps in the future.
+            OnPreLoad.RemoveApprovalSource(temporaryPreloadEvent);
         }
     }
 }


### PR DESCRIPTION
This PR revises the SGBManager's LoadSmileGameAsync function to support using the SGBMapLoadManager.

The SGBMapLoadManager has a new LoadMap function that utilizes it's Pre-Load operations to restrict the loading of any non-desired scenes. This is a quick bandaid around a race condition that is believed to exist.