### PR TITLE
Max Save File Count exposed via SGBSaveManager

### DIFF
--- a/Runtime/Scripts/SGBSaveManager.cs
+++ b/Runtime/Scripts/SGBSaveManager.cs
@@ -61,6 +61,11 @@ namespace BobboNet.SGB.IMod
         /// </summary>
         public static LoadDataDelegate LoadDataOverrideFunc { get; set; } = null;
 
+        /// <summary>
+        /// How many save files should SGB be allowed to display and store?
+        /// </summary>
+        public static int MaxSaveFileCount { get; set; } = 40;
+
         //
         //  Constructor
         //

--- a/Runtime/src/engine/MapScene/CommonWindow/SaveWindow.cs
+++ b/Runtime/src/engine/MapScene/CommonWindow/SaveWindow.cs
@@ -1,5 +1,6 @@
 ﻿// Custom overrides description
 // Resolution overrides, Margin corrections for the Save window selection options and message
+using BobboNet.SGB.IMod;
 using Microsoft.Xna.Framework;
 using Yukar.Common;
 
@@ -16,7 +17,11 @@ namespace Yukar.Engine
         {
             columnNum = 1;
             itemNumPerPage = 5;
+#if IMOD
+            maxItems = SGBSaveManager.MaxSaveFileCount;
+#else
             maxItems = 40;
+#endif
             itemHeight = 68;
             //pageMarkOffsetY = 22;
             marginRow = 1;
@@ -125,9 +130,9 @@ namespace Yukar.Engine
                 var touchPos = InputCore.getTouchPos(0);
                 var offsetX = (int)windowPos.X - innerWidth / 2;
                 var offsetY = (int)windowPos.Y - innerHeight / 2;
-                if (offsetX + maxWindowSize.X < touchPos.x 
-                    && touchPos.x < Graphics.ScreenWidth - offsetX 
-                    && offsetY < touchPos.y 
+                if (offsetX + maxWindowSize.X < touchPos.x
+                    && touchPos.x < Graphics.ScreenWidth - offsetX
+                    && offsetY < touchPos.y
                     && touchPos.y < maxWindowSize.Y)
                 {
                     if (returnSelected == 0) result = selected;


### PR DESCRIPTION
This PR revises the SGBSaveManager to expose the current max save file count of SGB's save file list.

This allows you to visually limit the number of save file slots.