### PR TITLE
IModOverlay Only Runs In Editor

### DIFF
--- a/Runtime/Scripts/IModOverlay.cs
+++ b/Runtime/Scripts/IModOverlay.cs
@@ -58,6 +58,13 @@ namespace BobboNet.SGB.IMod
 
         private void Awake()
         {
+            // If we're not in the editor, DESTROY THIS.
+            if (!Application.isEditor)
+            {
+                Destroy(gameObject);
+                return;
+            }
+
             buttonWindowToggle.onClick.AddListener(delegate ()
             {
                 SetWindowOpen(!windowIsOpen);


### PR DESCRIPTION
This PR tweaks the IModOverlay GameObject to only be visible in the editor. If it detects that the application is not the Unity Editor, then it will self destruct.