### PR TITLE
Smoother SGB Direct Map Loading

### DIFF
--- a/Runtime/src/engine/MapScene/MapScene.cs
+++ b/Runtime/src/engine/MapScene/MapScene.cs
@@ -822,7 +822,11 @@ namespace Yukar.Engine
 
         internal void Update()
         {
-            if (isLoading || isBattleLoading)
+            if (isLoading || isBattleLoading
+#if IMOD
+            || GameMain.isLoadingOverrideMap
+#endif
+            )
                 return;
 
             IsMapChangedFrame = false;


### PR DESCRIPTION
This PR makes direct map loading smoother by preventing SGB from updating the MapScene while a direct load is happening. This is super helpful if direct loading is happening across a few frame, like it does in Windows builds.