### PR TITLE
Bugfix - Unity2022+ Arial.ttf support

### DIFF
--- a/Runtime/Scripts/IModOverlay.cs
+++ b/Runtime/Scripts/IModOverlay.cs
@@ -121,7 +121,11 @@ namespace BobboNet.SGB.IMod
             newTextRect.sizeDelta = new Vector2(0, 0);
 
             // Set the button's font
+#if UNITY_2022_2_OR_NEWER
+            Font ArialFont = Resources.GetBuiltinResource<Font>("LegacyRuntime.ttf");
+#else
             Font ArialFont = (Font)Resources.GetBuiltinResource(typeof(Font), "Arial.ttf");
+#endif
             newText.font = ArialFont;
             newText.material = ArialFont.material;
             newText.color = Color.black;


### PR DESCRIPTION
This PR fixes a bug caused by Unity2022 deprecating Arial.ttf. A legacy font is now used instead, if the Unity version is 2022.2 or newer.