### PR TITLE
Bugfix - Render buffer not cleared on re-init

### DIFF
--- a/Runtime/Scripts/SGBManager.cs
+++ b/Runtime/Scripts/SGBManager.cs
@@ -201,6 +201,7 @@ namespace BobboNet.SGB.IMod
             UnityEntry.self = entry;
 
             SharpKmyGfx.Render.InitializeRender();
+            UnityEntry.blackout(); // Fill the renderer with black. If we don't do this, there may be some leftover data in the render buffer.
             Yukar.Common.UnityUtil.Initialize();
 #if !UNITY_EDITOR
             Debug.unityLogger.logEnabled = false;


### PR DESCRIPTION
This PR fixes a bug where upon loading SGB after previously unloading it, the render buffer is not cleared. This resulted in some behaviour where the last drawn frame from a previous load would appear instead of the initial all-black loading screen.